### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redirects the old NixOS wiki to the new URL
 
-This web browser extension redirects all nixos.wiki links to wiki.nixos.org.
+This web browser extension redirects all wiki.nixos.org links to wiki.nixos.org.
 * 12 lines of code, will not eat your homework.
 
 TODO: to make it easy to install these types of extensions, they need to be signed and uploaded to addons.mozilla.org.

--- a/background.js
+++ b/background.js
@@ -5,7 +5,7 @@ browser.webRequest.onBeforeRequest.addListener(
     };
   },
   {
-    urls: ["*://nixos.wiki/*"],
+    urls: ["*://wiki.nixos.org/*"],
     types: ["main_frame"]
   },
   ["blocking"]

--- a/manifest.json
+++ b/manifest.json
@@ -2,11 +2,11 @@
   "manifest_version": 2,
   "name": "NixOS Wiki Redirect",
   "version": "1.0",
-  "description": "Redirects nixos.wiki to wiki.nixos.org",
+  "description": "Redirects wiki.nixos.org to wiki.nixos.org",
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-    "*://nixos.wiki/*"
+    "*://wiki.nixos.org/*"
   ],
   "applications": {
     "gecko": {


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️